### PR TITLE
fixed deprecated syntax typealias and Base.SingleAsyncWork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,22 @@ matrix:
         apt:
           packages:
             - jackd2
+    - julia: 0.6
+      os: linux
+      env:
+        - JACKD=1
+      addons:
+        apt:
+          packages:
+            - jackd1
+    - julia: 0.6
+      os: linux
+      env:
+        - JACKD=2
+      addons:
+        apt:
+          packages:
+            - jackd2
 script:
  - jackd -r -p24 -ddummy -r48000 -p2048 &
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/src/JACKAudio.jl
+++ b/src/JACKAudio.jl
@@ -145,7 +145,7 @@ type JACKClient
     # process callback all the pointers it needs for the source/sink ports and
     # ringbuffers
     portptrs::Ptr{Ptr{Void}}
-    callback::Base.SingleAsyncWork
+    callback::Base.AsyncCondition
 
     # this constructor takes a list of name, channelcount pairs
     function JACKClient{T1 <: Tuple, T2 <: Tuple}(
@@ -226,7 +226,7 @@ type JACKClient
         unsafe_store!(portptrs, C_NULL, ptridx)
         ptridx += 1
 
-        client.callback = Base.SingleAsyncWork(data -> managebuffers(client))
+        client.callback = Base.AsyncCondition(data -> managebuffers(client))
 
         # and finally we store the callback handle so the JACK process callback
         # can trigger the managebuffers function to run in the julia context

--- a/src/libjack.jl
+++ b/src/libjack.jl
@@ -1,12 +1,12 @@
-typealias ClientPtr Ptr{Void}
-typealias PortPtr Ptr{Void}
-typealias CFunPtr Ptr{Void}
-typealias NFrames UInt32
-typealias JACKSample Cfloat
+const ClientPtr = Ptr{Void}
+const PortPtr = Ptr{Void}
+const CFunPtr = Ptr{Void}
+const NFrames = UInt32
+const JACKSample = Cfloat
 
 const JACK_DEFAULT_AUDIO_TYPE = "32 bit float mono audio"
 
-# this mirrors the struct defined in ringbuffer.h
+# this mirrors the struct defined in ringbuffer.h 
 type RingBuf
     buf::Ptr{Cchar}
     write_ptr::Csize_t
@@ -16,7 +16,7 @@ type RingBuf
     mlocked::Cint
 end
 # add typealias for consistency with other *Ptr types
-typealias RingBufPtr Ptr{RingBuf}
+const RingBufPtr = Ptr{RingBuf}
 
 @enum(Option,
     # Null value to use when no option bits are needed.


### PR DESCRIPTION
It should now work with julia 0.6.0. 